### PR TITLE
Make image excerpts work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ _site/
 .jekyll-cache/
 .jekyll-metadata
 .DS_Store
+.bundle
+vendor/

--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,9 @@ description: > # this means to ignore newlines until the next setting.
   way to get started with ChatOps.
 repository: aseriousbiz/blog
 
+# social
+twitter_username: getAbbot
+
 # Google Analytics
 google_analytics: GTM-PMQPWV8
 
@@ -33,6 +36,11 @@ kramdown:
 remote_theme: aseriousbiz/blog-theme@main
 
 exclude: [README.md CODE_OF_CONDUCT.md script .gitattributes .gitignore keybase.txt RakeFile]
+exclude:
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
 keep_files: [robots.txt favicon.ico]
 incremental: true
 

--- a/_posts/2021/2021-06-08-user-interface-support.md
+++ b/_posts/2021/2021-06-08-user-interface-support.md
@@ -2,7 +2,7 @@
 title: "Support User Interactions With Buttons"
 description: "Abbot skills can now support user interactions through user interface elements. In the latest release, Abbot skills may include buttons in a response that the user can click (Teams and Slack only)."
 tags: [abbot, ui, buttons]
-image: https://user-images.githubusercontent.com/19977/121226165-196cfd00-c83f-11eb-8b59-04b3a33e99f8.png
+excerpt_image: https://user-images.githubusercontent.com/19977/121226165-196cfd00-c83f-11eb-8b59-04b3a33e99f8.png
 author:
     avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
     name: haacked


### PR DESCRIPTION
After taking a look at the blog theme, it turns out all we needed to do to fix image excerpts for Twitter was to set our Twitter handle in the config. 

This PR reverts the earlier test change of `excerpt_image` -> `image`, sets our Twitter handle in the config, and ignores some vendor stuff from running this locally. Fixes #2.