### PR TITLE
Add image titles to the excerpts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,30 @@
 # The Abbot Blog
 
 A blog about Abbot
+
+## How To Image
+
+Ideally, every blog post has a main image. Our homepage lists all our blog post titles and have a brief excerpt of the post. The main image also shows up here by using an `excerpt_image` field in the front-matter.
+
+We also put the main image in the content of the post, usually after the first paragraph of the post.
+
+Each image must have an `alt` tag that describes the content of the image. Ideally we also add some title text.
+
+For example:
+
+`![Alt text describes content of image for vision impared](https://url-to-image "Title text provides a caption to the image")`
+
+Note that we have some JavaScript that renders the title of the image below the image below the image like so:
+
+![Screen Shot 2021-11-05 at 3 11 38 PM](https://user-images.githubusercontent.com/19977/140584230-99e8b190-ec24-47a2-8a1a-036091e1d977.png)
+
+The title text is a great opportunity to add some funny commentary or extra context to the image. For images that we did not create, we should use the title to provide attribution for the image.
+
+Here's an example of how we make sure the alt tag and title text show up in the homepage excerpt.
+
+```yaml
+excerpt_image:
+    url: https://user-images.githubusercontent.com/19977/139963499-5f0db4c3-a72e-4bad-8419-d1ac247c676c.jpeg
+    title: Puzzle image dedicated to the public domain by the author.
+    alt: Puzzle with last piece fitting into the last piece of the puzzle.
+```

--- a/_posts/2021/2021-02-11-introducing-abbot.markdown
+++ b/_posts/2021/2021-02-11-introducing-abbot.markdown
@@ -2,7 +2,9 @@
 title: "Introducing Abbot, a powerful ChatOps tool for collaborative work"
 description: "Introducing Abbot, your friendly neighborhood chat bot. It's the best way to automate tasks from chat to work together with others."
 tags: [abbot,chatops,remote work]
-excerpt_image: https://user-images.githubusercontent.com/19977/107439587-26731d00-6ae7-11eb-925c-0f50f09f2969.png
+excerpt_image:
+    url: https://user-images.githubusercontent.com/19977/107439587-26731d00-6ae7-11eb-925c-0f50f09f2969.png
+    title: "I am ready to do the thing."
 author:
     avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
     name: haacked

--- a/_posts/2021/2021-02-11-introducing-abbot.markdown
+++ b/_posts/2021/2021-02-11-introducing-abbot.markdown
@@ -5,6 +5,7 @@ tags: [abbot,chatops,remote work]
 excerpt_image:
     url: https://user-images.githubusercontent.com/19977/107439587-26731d00-6ae7-11eb-925c-0f50f09f2969.png
     title: "I am ready to do the thing."
+    alt: Image of Abbot, a robot, against a purple background
 author:
     avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
     name: haacked

--- a/_posts/2021/2021-02-12-argument-parsing-with-abbot.markdown
+++ b/_posts/2021/2021-02-12-argument-parsing-with-abbot.markdown
@@ -2,7 +2,9 @@
 title: "Argument parsing with Abbot"
 description: "Abbot has some neat built-in tools for argument parsing that make use of C# tuple deconstruction for fun and profit."
 tags: [abbot,chatops,csharp]
-excerpt_image: https://user-images.githubusercontent.com/19977/107692389-92799080-6c61-11eb-9710-c75811b528ee.jpg
+excerpt_image:
+    url: https://user-images.githubusercontent.com/19977/107692389-92799080-6c61-11eb-9710-c75811b528ee.jpg
+    title: "The feeling I get when I parse arguments with a regular expression"
 author:
     avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
     name: haacked

--- a/_posts/2021/2021-02-12-argument-parsing-with-abbot.markdown
+++ b/_posts/2021/2021-02-12-argument-parsing-with-abbot.markdown
@@ -4,7 +4,8 @@ description: "Abbot has some neat built-in tools for argument parsing that make 
 tags: [abbot,chatops,csharp]
 excerpt_image:
     url: https://user-images.githubusercontent.com/19977/107692389-92799080-6c61-11eb-9710-c75811b528ee.jpg
-    title: "The feeling I get when I parse arguments with a regular expression"
+    title: "The feeling I get when I parse arguments with a regular expression - Simplified Pixabay License"
+    alt: Image of woman slugging a man
 author:
     avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
     name: haacked
@@ -16,7 +17,7 @@ Abbot doesn't strive for true natural language processing yet because many skill
 
 To achieve a more natural language feel, Bot skills tend to have a pretty simple format for the arguments passed to the skill. But even a simple format can require a fairly complex regular expression to parse correctly. And we all know what happens when you decide to [use a regular expression to solve a problem](http://regex.info/blog/2006-09-15/247). Spending a day writing regular expressions can make you feel like you've been slugged.
 
-![Image of woman slugging a man - Simplified Pixabay License](https://user-images.githubusercontent.com/19977/107692389-92799080-6c61-11eb-9710-c75811b528ee.jpg "The feeling I get when I parse arguments with a regular expression")
+![Image of woman slugging a man](https://user-images.githubusercontent.com/19977/107692389-92799080-6c61-11eb-9710-c75811b528ee.jpg "The feeling I get when I parse arguments with a regular expression - Simplified Pixabay License")
 
 Let's follow an example to see what I mean. Suppose we have a skill for managing another user's favorite songs with the following usage pattern.
 

--- a/_posts/2021/2021-02-19-writing-abbot-skill-in-csharp.markdown
+++ b/_posts/2021/2021-02-19-writing-abbot-skill-in-csharp.markdown
@@ -2,7 +2,9 @@
 title: "Writing Sparkly Abbot Skills With C#"
 description: "This video walks through writing a skill to give your friends and colleagues :sparkles:."
 tags: [abbot,chatops,csharp]
-excerpt_image: https://user-images.githubusercontent.com/19977/108565585-c7b55c80-72b9-11eb-93bb-db25dd0febb2.png
+excerpt_image:
+    url: https://user-images.githubusercontent.com/19977/108565585-c7b55c80-72b9-11eb-93bb-db25dd0febb2.png
+    alt: "Screenshot from a YouTube video showing the Abbot skill editor."
 author:
     avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
     name: haacked

--- a/_posts/2021/2021-03-04-abbot-cloud-events.markdown
+++ b/_posts/2021/2021-03-04-abbot-cloud-events.markdown
@@ -2,7 +2,9 @@
 title: "Subscribing to cloud events with Abbot"
 description: "Subscribe to notifications about important events in your cloud infrastructure using Abbot in a few easy steps!"
 tags: [abbot,chatops,csharp]
-excerpt_image: https://user-images.githubusercontent.com/19977/110027163-7f009900-7ce6-11eb-8aba-5b1d96ef0b6d.png
+excerpt_image:
+    url: https://user-images.githubusercontent.com/19977/110027163-7f009900-7ce6-11eb-8aba-5b1d96ef0b6d.png
+    alt: "Screenshot from a YouTube video showing the package listing for the cloud-event skill."
 author:
     avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
     name: haacked

--- a/_posts/2021/2021-06-08-user-interface-support.md
+++ b/_posts/2021/2021-06-08-user-interface-support.md
@@ -2,7 +2,10 @@
 title: "Support User Interactions With Buttons"
 description: "Abbot skills can now support user interactions through user interface elements. In the latest release, Abbot skills may include buttons in a response that the user can click (Teams and Slack only)."
 tags: [abbot, ui, buttons]
-excerpt_image: https://user-images.githubusercontent.com/19977/121226165-196cfd00-c83f-11eb-8b59-04b3a33e99f8.png
+excerpt_image:
+    url: https://user-images.githubusercontent.com/19977/121226165-196cfd00-c83f-11eb-8b59-04b3a33e99f8.png
+    alt: Image of Robby the Robot with two button choices. Is the subject a bot or not? Phil chose the correct answer.
+    title: "It's a tough question but I believe in Phil."
 author:
     avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
     name: haacked
@@ -210,7 +213,7 @@ else:
 
 And here's what it looks like in Slack.
 
-<img width="477" alt="Image of Robby the Robot with two button choices. Is the subject a bot or not? Phil chose the correct answer." src="https://user-images.githubusercontent.com/19977/121226165-196cfd00-c83f-11eb-8b59-04b3a33e99f8.png" />
+<img width="477" alt="Image of Robby the Robot with two button choices. Is the subject a bot or not? Phil chose the correct answer." src="https://user-images.githubusercontent.com/19977/121226165-196cfd00-c83f-11eb-8b59-04b3a33e99f8.png" title="It's a tough question but I believe in Phil." />
 
 And here it is in Teams.
 

--- a/_posts/2021/2021-06-21-andreia-is-an-abboteer.md
+++ b/_posts/2021/2021-06-21-andreia-is-an-abboteer.md
@@ -2,7 +2,9 @@
 title: "Andreia 'Shana' Gaita is an Abboteer"
 description: "We are thrilled to welcome Employee #1, Andreia Gaita to A Serious Business, Inc."
 tags: [team, new-hire, abboteer]
-excerpt_image: https://user-images.githubusercontent.com/19977/122487693-b2fb8380-cf90-11eb-9719-8c2b2f8ee84c.jpeg
+excerpt_image:
+    url: https://user-images.githubusercontent.com/19977/122487693-b2fb8380-cf90-11eb-9719-8c2b2f8ee84c.jpeg
+    title: "Shana searches for that last bug"
 author:
     avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
     name: haacked
@@ -10,7 +12,7 @@ author:
 
 Today marks [Shana's](https://twitter.com/sh4na) first day as an Abboteer (yes, we're going to try and make that term a thing) joining us all the way from Portugal! Shana is known for diving deep into a challenge. She enjoys gaming, diving, and redefining which way is up.
 
-![Shana searches for that last bug](https://user-images.githubusercontent.com/19977/122487693-b2fb8380-cf90-11eb-9719-8c2b2f8ee84c.jpeg)
+![Image of a Shana in scuba gear upside down underwater](https://user-images.githubusercontent.com/19977/122487693-b2fb8380-cf90-11eb-9719-8c2b2f8ee84c.jpeg "Shana searches for that last bug")
 
 We worked together at [GitHub](https://github.com/) where we learned just how talented and formidable an engineer she is. We couldn't be more excited that she's our first hire!
 

--- a/_posts/2021/2021-06-21-andreia-is-an-abboteer.md
+++ b/_posts/2021/2021-06-21-andreia-is-an-abboteer.md
@@ -5,6 +5,7 @@ tags: [team, new-hire, abboteer]
 excerpt_image:
     url: https://user-images.githubusercontent.com/19977/122487693-b2fb8380-cf90-11eb-9719-8c2b2f8ee84c.jpeg
     title: "Shana searches for that last bug"
+    alt: "Image of a Shana in scuba gear upside down underwater"
 author:
     avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
     name: haacked

--- a/_posts/2021/2021-06-22-shipit.md
+++ b/_posts/2021/2021-06-22-shipit.md
@@ -2,7 +2,9 @@
 title: "Ship It Squirrel and list skills"
 description: "Using lists in Abbot for fun and camaraderie. The story of the shipit squirrel skill and encouraging shipping. Go ship it!"
 tags: [lists,abbot]
-excerpt_image: https://user-images.githubusercontent.com/19977/122805857-796f9480-d27e-11eb-8ee8-ccb335d14f23.png
+excerpt_image:
+    url: https://user-images.githubusercontent.com/19977/122805857-796f9480-d27e-11eb-8ee8-ccb335d14f23.png
+    title: "The famous Ship It Squirrel"
 author:
     avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
     name: haacked
@@ -14,7 +16,7 @@ Ship early and ship often. This is a principle we embrace and celebrate here at 
 
 The shipping mascot mentioned in the post is the famous Ship It Squirrel!
 
-![Shipit Squirrel](https://user-images.githubusercontent.com/19977/122805857-796f9480-d27e-11eb-8ee8-ccb335d14f23.png).
+![Squirrel in front of a couple posing by a fjord. The squirrel says "Ship It!"](https://user-images.githubusercontent.com/19977/122805857-796f9480-d27e-11eb-8ee8-ccb335d14f23.png "The famous Ship It Squirrel").
 
 The Ship It Squirrel showed up everywhere. If a Pull Request was ready to go, we'd comment on the PR with the :shipit: emoji. In chat, we had a [Hubot](https://hubot.github.com/) script we could call that posted a random Ship It Squirrel into the chat room. The [hubot-shipit](https://github.com/hubot-scripts/hubot-shipit) script still lives on! It's a nice way to encourage each other.
 

--- a/_posts/2021/2021-06-22-shipit.md
+++ b/_posts/2021/2021-06-22-shipit.md
@@ -5,6 +5,7 @@ tags: [lists,abbot]
 excerpt_image:
     url: https://user-images.githubusercontent.com/19977/122805857-796f9480-d27e-11eb-8ee8-ccb335d14f23.png
     title: "The famous Ship It Squirrel"
+    alt: Squirrel in front of a couple posing by a fjord. The squirrel says Ship It!
 author:
     avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
     name: haacked
@@ -16,7 +17,7 @@ Ship early and ship often. This is a principle we embrace and celebrate here at 
 
 The shipping mascot mentioned in the post is the famous Ship It Squirrel!
 
-![Squirrel in front of a couple posing by a fjord. The squirrel says "Ship It!"](https://user-images.githubusercontent.com/19977/122805857-796f9480-d27e-11eb-8ee8-ccb335d14f23.png "The famous Ship It Squirrel").
+![Squirrel in front of a couple posing by a fjord. The squirrel says Ship It!](https://user-images.githubusercontent.com/19977/122805857-796f9480-d27e-11eb-8ee8-ccb335d14f23.png "The famous Ship It Squirrel").
 
 The Ship It Squirrel showed up everywhere. If a Pull Request was ready to go, we'd comment on the PR with the :shipit: emoji. In chat, we had a [Hubot](https://hubot.github.com/) script we could call that posted a random Ship It Squirrel into the chat room. The [hubot-shipit](https://github.com/hubot-scripts/hubot-shipit) script still lives on! It's a nice way to encourage each other.
 

--- a/_posts/2021/2021-06-28-manage-issues-in-chat.md
+++ b/_posts/2021/2021-06-28-manage-issues-in-chat.md
@@ -2,7 +2,9 @@
 title: "Manage GitHub issues in chat with Abbot"
 description: "Chat can be a great place to discuss issues and what to do about them. But why not go further and triage issues and assign them from chat? With the github skill, you can do all that and more! And the skill is customizable to fit your needs."
 tags: [github,issues]
-excerpt_image: https://user-images.githubusercontent.com/19977/123681438-b26bb400-d7fe-11eb-99bf-b73d8e47ba56.png
+excerpt_image:
+    url: https://user-images.githubusercontent.com/19977/123681438-b26bb400-d7fe-11eb-99bf-b73d8e47ba56.png
+    alt: Screenshot showing the github triage and assign commands
 author:
     avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
     name: haacked

--- a/_posts/2021/2021-06-30-query-data-from-chat.md
+++ b/_posts/2021/2021-06-30-query-data-from-chat.md
@@ -2,7 +2,9 @@
 title: "Query databases from chat with Abbot"
 description: "Chat is the perfect place to review data with your team. Abbot makes it easy to query your data and share it in chat."
 tags: [sql,data,dataclip]
-excerpt_image: https://user-images.githubusercontent.com/279389/124063486-d4745a80-d9e7-11eb-913a-e44ee5b46c55.png
+excerpt_image:
+  url: https://user-images.githubusercontent.com/279389/124063486-d4745a80-d9e7-11eb-913a-e44ee5b46c55.png
+  alt: Screenshot of running a query to count reactions occuring in chat
 author:
     avatar: https://avatars.githubusercontent.com/u/279389?v=4
     name: pmn
@@ -10,13 +12,15 @@ author:
 
 Chat is a great place to review data together. Abbot has always made interacting with APIs easy; and now Abbot can also talk to MySQL and Postgres databases.
 
+![Screenshot of running a query to count reactions occuring in chat](https://user-images.githubusercontent.com/279389/124063486-d4745a80-d9e7-11eb-913a-e44ee5b46c55.png)
+
 Here are some examples of what you can do with this new power:
 
 ## Run predefined reports from chat
 
 It can be a hassle to get reports from your database and into a spreadsheet, just so you can email them to your team. Having a set of pre-defined reports that your team can run at any time gives them the ability to review data on demand.
 
-Let's build a sql reporting skill in Abbot using Python. We'll use Pandas, since it provides so many tools for data manipulation. We will also include SQLAlchemy to manage the database connection. You will need a connection string to a database that Abbot can reach in order to write this skill. C# and JavaScript skills can also connect to databases! 
+Let's build a sql reporting skill in Abbot using Python. We'll use Pandas, since it provides so many tools for data manipulation. We will also include SQLAlchemy to manage the database connection. You will need a connection string to a database that Abbot can reach in order to write this skill. C# and JavaScript skills can also connect to databases!
 
 Start a new Python skill called `reports`, then create a secret called `connstr` with the connection string you created for your database. Once the skill and secret are created, add these lines to your skill:
 
@@ -74,6 +78,7 @@ bot.reply(result)
 Now when users say `@abbot reports newusers` it will run the query found in `newusers`. There isn't much in the way of error handling in this example, but you can see how simple it is to fill out queries for people to run. We published a [sql skill](https://ab.bot/packages/aseriousbiz/sql) in the Package Directory that you can use as the basis for your own querying from chat.
 
 ## Searching for information
+
 Customer-facing teams often need to look up user data when talking with customers. Instead of building an entire website for customer lookup, it can be replaced with a simple Abbot skill. 
 
 Create a new skill called `lookup`, and copy over the same template we used from the `reports` skill. We will make a simple change to the query, and everything should work. Note that we parameterize the query to spoil the fun of any trolls we might have in our chat.
@@ -94,9 +99,11 @@ df = pandas.read_sql(query,
 Run this skill by saying `@abbot lookup yadda` where `yadda` is contained in the Name field of your table. This will give you a list of organizations that match. Get extra credit by forming the correct URLs for each organization when you return the data so that your customer teams can click a link to view their customer record.
 
 ## The Danger Zone
+
 With great power comes great responsibility. It's possible to create a skill that allows people to execute arbitrary SQL commands from chat. It's up to you and your team to decide if that's a good idea or not; if you do decide to walk on the wild side, Abbot has built-in auditing and [access controls](https://youtu.be/6NHMyyWZtrU). Be sure to limit who can run these sorts of skills in your chat by restricting the skill before you release it.
 
 ## What about Heroku Dataclips?
+
 If you're using Heroku Dataclips, fetching the data and returning it in chat can be as simple as the following (make sure `clipurl` contains the URL for your Dataclip CSV): 
 
 ```python
@@ -105,9 +112,10 @@ df = pandas.read_csv(bot.secrets.read("clipurl"))
 bot.reply("```{}```".format(df.to_markdown()))
 ```
 
-That's all there is to it! 
+That's all there is to it!
 
 ## Wrapping up
+
 It's easy to imagine what's possible once an Abbot skill can connect to external databases, especially when combined with [HTTP Triggers](https://docs.ab.bot/guides/triggers/), access controls, and built-in auditing. The source code to the `sql` package is [available on GitHub](https://github.com/aseriousbiz/abbot-skills/blob/main/skills/sql.py) as well, if you'd like to use it for the basis for your own skills.
 
 Please let us know if you have a use case that requires you to connect with a database we don't yet support. We'd love to talk to you about it! 

--- a/_posts/2021/2021-06-30-query-data-from-chat.md
+++ b/_posts/2021/2021-06-30-query-data-from-chat.md
@@ -13,6 +13,7 @@ Chat is a great place to review data together. Abbot has always made interacting
 Here are some examples of what you can do with this new power:
 
 ## Run predefined reports from chat
+
 It can be a hassle to get reports from your database and into a spreadsheet, just so you can email them to your team. Having a set of pre-defined reports that your team can run at any time gives them the ability to review data on demand.
 
 Let's build a sql reporting skill in Abbot using Python. We'll use Pandas, since it provides so many tools for data manipulation. We will also include SQLAlchemy to manage the database connection. You will need a connection string to a database that Abbot can reach in order to write this skill. C# and JavaScript skills can also connect to databases! 

--- a/_posts/2021/2021-07-01-graphs-in-chat.markdown
+++ b/_posts/2021/2021-07-01-graphs-in-chat.markdown
@@ -2,7 +2,10 @@
 title: "Visualize Grafana dashboards in chat"
 description: "The grafana skill lets you quickly see all your Grafana dashboards and visualize custom graph queries without leaving your chat window."
 tags: [grafana,graphs]
-excerpt_image: https://user-images.githubusercontent.com/310137/124177982-4369b600-dab1-11eb-84eb-33f3ba1d23c4.png
+excerpt_image:
+    url: https://user-images.githubusercontent.com/310137/124177982-4369b600-dab1-11eb-84eb-33f3ba1d23c4.png
+    alt: Screenshot showing several graphs of the Home dashboard
+    title: Graph all of the things.
 author:
     avatar: https://gravatar.com/avatar/dc6fa84a4a864f9627e220b716572cba?s=160
     name: shana
@@ -36,7 +39,7 @@ The main command for the Grafana skill is `db`, for dashboard. To see all the pa
 
 Dashboard names are case insensitive and can be partial, so if you have a dashboard with a long name, you don't have to write it all in full.
 
-![Screenshot showing several graphs of the Home dashboard](https://user-images.githubusercontent.com/310137/124183379-6a77b600-dab8-11eb-92a7-91af9d60b21c.png)
+![Screenshot showing several graphs of the Home dashboard](https://user-images.githubusercontent.com/310137/124183379-6a77b600-dab8-11eb-92a7-91af9d60b21c.png "Graph all of the things")
 
 You probably don't want to see all the panels of a dashboard all the time though - you will likely have specific graphs you want to generate at certain times. To see a graph of a specific panel of a dashboard, add a colon and the panel name after the dashboard name to the `db` query, like so:
 

--- a/_posts/2021/2021-07-01-graphs-in-chat.markdown
+++ b/_posts/2021/2021-07-01-graphs-in-chat.markdown
@@ -13,6 +13,7 @@ An image is worth a thousand words, which is why [Abbot](https://ab.bot/) can no
 List all your dashboards and quickly query your panels, generating graphs with custom time ranges and template variables to suit your visualization needs.
 
 ## Setting it up
+
 Before you can start visualizing all your graphs, you need to tell Abbot where to go to get them.
 
 Start by generating a Grafana API key on your Grafana host, usually found at `https://your-grafana-host/org/apikeys`. Then, visit [https://ab.bot/skills/grafana](https://ab.bot/skills/grafana) and click "Manage skill secrets" to add a secret named ___GrafanaKey___, with the key you created.
@@ -26,6 +27,7 @@ In chat, tell Abbot where your Grafana host is with
 Once the API key and the host configuration are done, you're ready to graph!
 
 ## Graphs in action
+
 The main command for the Grafana skill is `db`, for dashboard. To see all the panels of your _Home_ dashboard, run
 
 ```bash
@@ -35,7 +37,6 @@ The main command for the Grafana skill is `db`, for dashboard. To see all the pa
 Dashboard names are case insensitive and can be partial, so if you have a dashboard with a long name, you don't have to write it all in full.
 
 ![Screenshot showing several graphs of the Home dashboard](https://user-images.githubusercontent.com/310137/124183379-6a77b600-dab8-11eb-92a7-91af9d60b21c.png)
-
 
 You probably don't want to see all the panels of a dashboard all the time though - you will likely have specific graphs you want to generate at certain times. To see a graph of a specific panel of a dashboard, add a colon and the panel name after the dashboard name to the `db` query, like so:
 
@@ -62,8 +63,8 @@ You can also use the panel ID instead, so you don't have to type the whole thing
 
 ![Screenshot of a graph of a panel by ID](https://user-images.githubusercontent.com/310137/124185258-05718f80-dabb-11eb-8f26-2edfefcfd3e8.png)
 
-
 ## Customize your graphs
+
 Grafana graphs support templated variables and a host of other customization options, and you can use all of those from chat as well - the skill supports custom queries with time ranges, template variables, timezone specifications and size constraints.
 
 Most often, you'll want to customize the time window of your graph. You can specify a range by adding time parameters to your query:
@@ -76,13 +77,11 @@ This generates a graph of the `logins` panel in the `Home` dashboard with a time
 
 Time parameters are optional, and if you only have one, it will be interpreted as a window of "now - Time" to now.
 
-
 ```bash
 @abbot grafana db "grafana dashboard:client side full page load" 24h var-app=backend var-server=backend_01 var-server=backend_03 var-interval=1h
 ```
 
 The more complex query above generates a templated Grafana graph with a time window of 24 hours, customized with several variables.
-
 
 ![Screenshot showing a graph with custom ranges and template variables](https://user-images.githubusercontent.com/310137/124180188-28e50c00-dab4-11eb-9398-d3333323bae0.png)
 

--- a/_posts/2021/2021-07-15-tools-for-inside-the-workshop.md
+++ b/_posts/2021/2021-07-15-tools-for-inside-the-workshop.md
@@ -8,7 +8,7 @@ author:
     name: pmn
 ---
  
-No two workshops are the same. Well-used workshops form a patina of scars, wear marks, and scratches on the floor over time, giving them their own unique fingerprint. Look inside one and you'll notice something else: the tools that the craftspeople made for themselves to use inside the workshop. These purpose-built tools create a special language in the workshop, a patois evolved from the shared experiences of building. 
+No two workshops are the same. Well-used workshops form a patina of scars, wear marks, and scratches on the floor over time, giving them their own unique fingerprint. Look inside one and you'll notice something else: the tools that the craftspeople made for themselves to use inside the workshop. These purpose-built tools create a special language in the workshop, a patois evolved from the shared experiences of building.
 
 As people change jobs, they bring the best of the tools they used at their last shop with them. They may not work exactly the same way in the new place; but it makes a great starting point for helping everyone else build faster, more accurately, and with less effort. Some of these tools are bought off the shelf, but often there are tools that are made to fill a specific need quickly and simply.
 
@@ -19,12 +19,11 @@ In the physical world, these tools are assembled with a few pieces of whatever i
 
 ![Many tools on a wall inside a workshop](https://user-images.githubusercontent.com/279389/125671459-9eb8385d-66a0-4010-9d77-49a00f9919f5.jpg)
 
-
 ## Abbot helps you build tools for inside your workshop
+
 It may not be the place where individual work is done, but chat is the workshop for technology companies today. It's where people gather to talk, make decisions, coordinate, and collaborate. We designed Abbot to make building tools for inside this workshop as simple as possible. Because we supply the infrastructure that runs these tools, builders and makers can focus on what’s essential – the logic for their script. Since Abbot tracks who writes and runs the code, who accesses secrets, where data is stored (and much more); developers are freed from having to write yet another web app to kick off a scheduled job, or from having to keep tabs on a rarely touched system just to make sure things are working.
 
 This allows teams to build the smallest possible units of automation. For example, we have an Abbot skill called `strlen` that returns the length of a string and the number of words it contains. It’s only three lines of code [^1], but we use it a few times a week. **Without Abbot, we would never build a tool like this.** It’s far too much work to build a chat integration for such small things; but because we have made it simple to build these, we have dozens like it. Working this way is incredibly freeing. Instead of opening a Python shell to script something locally, Abbot's REPL [^2] makes it trivial to write, test, and share this code with everyone.
-
 
 ## The Joy of Simple Automation
 
@@ -38,6 +37,7 @@ We saw this at work at GitHub with [Hubot](https://github.com/github/hubot). Nea
 When it’s possible for people to create their own tools internally with a minimum of fuss, more people create them. By doing it through Abbot, teams get a lot for free. Abbot provides a safe sandbox for developers to put their scripts. Since everything is logged and there is a permission system built in, administrators can feel confident about what’s happening on their Abbot installation.
 
 ## Minimum Shareable Products
+
 Many of our most used skills began as a quick experiment, often built during a short video call while we explored a problem space. It's easy to grow skills as they get used, and we've found there's no better way to build a skill than to start using it and growing it organically over time.
 
 Because we abstract away nearly all of the infrastructure for running skills, it's easy to share them. Abbot skills work everywhere that Abbot does, so developers don't have to think about whether or not the skill will be run in Slack, Discord, or Microsoft Teams. Copying and pasting code can be annoying, so we built Abbot's [Package Directory](https://ab.bot/packages) very early on. Even simple skills are worth sharing. One of the first skills ever shared in the directory taught Abbot how to [roll dice](https://ab.bot/packages/336298988896518154/roll), for example. We share a lot of the skills we build to help save people time. There's no reason to reinvent the wheel (or the [sparkles](https://ab.bot/packages/seriousdemos/sparkle), for that matter).
@@ -45,22 +45,23 @@ Because we abstract away nearly all of the infrastructure for running skills, it
 Skills installed from the Package Directory are treated the same way as skills built by your team. In fact, you get access to the source code for all skills shared in the directory so you can make any modifications you'd like. In addition, these skills benefit from the same supporting infrastructure as all other Abbot skills. Integrated help, discovery, permissions all work the same as skills you built yourself.
 
 ## Collaboration is fun
+
 You may be surprised to learn that we like a little fun at A Serious Business, Inc. These skills are a great way to ship a little piece of your team's personality into your workspace. Just like you might have a hammer with a hot pink handle in the shop named "The Smashinator", you can make some fun things for your team to use with Abbot as well. We make heavy use of [custom lists](https://blog.ab.bot/archive/2021/06/22/shipit/) to tell people when we're excited, or to keep track of our favorite robot jokes. There's even an installable package for [pugs on demand](https://ab.bot/packages/aseriousbiz/pug).
 
 It turns out that shipping your sense of humor (or lack thereof) into chat can be a pretty great team building experience. If your team works remotely even some of the time, having some fun inside the shop makes working together a lot more enjoyable.
 
 We've worked to make getting started with Abbot as easy as possible. The next time you find yourself thinking that you wished you had a tool in chat, no matter how small, please install Abbot and give it a try. We're confident you can have your first skill built and working in chat faster than you'd be able to clone and host any bot framework. As always, we're looking forward to your feedback and suggestions on how to improve Abbot. Just say `@abbot feedback` in chat to send it our way!
 
-
-
 **Footnotes**
 
-[^1]: [Create a new Python skill](https://ab.bot/skills/create/python) in Abbot and paste this code to have your own `@abbot strlen` command: 
-    ```python
-    words = len(bot.arguments.split())
-    chars = len(bot.arguments)
-    bot.reply("Your string is {} characters long ({} words)".format(chars, words))
-    ```
+[^1]: [Create a new Python skill](https://ab.bot/skills/create/python) in Abbot and paste this code to have your own `@abbot strlen` command:
+
+```python
+words = len(bot.arguments.split())
+chars = len(bot.arguments)
+bot.reply("Your string is {} characters long ({} words)".format(chars, words))
+```
+
 [^2]: [read-eval-print-loop](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)
 
 

--- a/_posts/2021/2021-07-15-tools-for-inside-the-workshop.md
+++ b/_posts/2021/2021-07-15-tools-for-inside-the-workshop.md
@@ -2,7 +2,9 @@
 title: "Tools For Inside the Workshop"
 description: "Abbot brings a different style of work to teams, where people build tools for themselves and each other."
 tags: [tools, devtools, chatops]
-excerpt_image: https://user-images.githubusercontent.com/279389/125671459-9eb8385d-66a0-4010-9d77-49a00f9919f5.jpg
+excerpt_image:
+    url: https://user-images.githubusercontent.com/279389/125671459-9eb8385d-66a0-4010-9d77-49a00f9919f5.jpg
+    alt: Many tools on a wall inside a workshop
 author:
     avatar: https://avatars.githubusercontent.com/u/279389?v=4
     name: pmn

--- a/_posts/2021/2021-07-27-tweet-from-chat.md
+++ b/_posts/2021/2021-07-27-tweet-from-chat.md
@@ -2,7 +2,9 @@
 title: "Tweet from Chat"
 description: "Never tweet from the wrong account again. Use the Abbot tweet skill to manage your company or team's Twitter account from chat."
 tags: [twitter]
-excerpt_image: https://user-images.githubusercontent.com/19977/127073042-60c19aee-62d2-4bea-ad6c-7028395defcc.png
+excerpt_image:
+    url: https://user-images.githubusercontent.com/19977/127073042-60c19aee-62d2-4bea-ad6c-7028395defcc.png
+    title: "That probably ended a career."
 author:
     avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
     name: haacked
@@ -10,7 +12,7 @@ author:
 
 If you manage more than one Twitter account, whether it's for a project or a company's social media presence, you live with THE FEAR. That nagging fear that takes up residence in the back of your mind. The fear that one day, you *will* tweet something inappropriate from the wrong account. I've done it. Maybe you've done it. But lets all hope it's not as bad as what this person did:
 
-![Failed tweet from a StubHub account: Thank Frank it's Friday! Can't wait to get out of this stubsucking hell hole.](https://user-images.githubusercontent.com/19977/127176682-1410a4e4-e092-48b0-9653-b120f5e0d147.jpeg)
+![Failed tweet from a StubHub account: Thank Frank it's Friday! Can't wait to get out of this stubsucking hell hole.](https://user-images.githubusercontent.com/19977/127176682-1410a4e4-e092-48b0-9653-b120f5e0d147.jpeg "That probably ended a career.")
 
 _(image from [Gawker](https://gawker.com/5949503/the-social-media-director-at-stubhub-is-not-having-a-good-night))_
 

--- a/_posts/2021/2021-07-27-tweet-from-chat.md
+++ b/_posts/2021/2021-07-27-tweet-from-chat.md
@@ -5,6 +5,7 @@ tags: [twitter]
 excerpt_image:
     url: https://user-images.githubusercontent.com/19977/127073042-60c19aee-62d2-4bea-ad6c-7028395defcc.png
     title: "That probably ended a career."
+    alt: "Failed tweet from a StubHub account: Thank Frank it's Friday! Can't wait to get out of this stubsucking hell hole."
 author:
     avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
     name: haacked

--- a/_posts/2021/2021-08-31-abbot-cli.md
+++ b/_posts/2021/2021-08-31-abbot-cli.md
@@ -2,7 +2,9 @@
 title: "Edit Abbot skills in your favorite editor"
 description: "The new experimental Abbot Command Line tool lets you edit Abbot skills in your favorite editor on your own machine."
 tags: [abbot-cli editing]
-excerpt_image: https://user-images.githubusercontent.com/19977/131401537-533115bd-545f-4cf6-8b38-14000258e9e1.png
+excerpt_image:
+    url: https://user-images.githubusercontent.com/19977/131401537-533115bd-545f-4cf6-8b38-14000258e9e1.png
+    alt: Screen shot of VS Code showing Intellisense for Bot
 author:
     avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
     name: haacked

--- a/_posts/2021/2021-09-13-don-okuda-is-an-abboteer.md
+++ b/_posts/2021/2021-09-13-don-okuda-is-an-abboteer.md
@@ -5,6 +5,7 @@ tags: [team, new-hire, abboteer]
 excerpt_image:
     url: https://user-images.githubusercontent.com/279389/133147424-0cfa12fd-12d3-4e71-9ab8-97e58a041901.jpg
     title: "Don made a clean escape so he could join us"
+    alt: Don Okuda bundled inside a washing machine with clothes and just his head peeking out.
 author:
     avatar: https://avatars.githubusercontent.com/u/279389?s=400&u=74e6e598a2bf9d9889fbb771c542c508bf270e36
     name: pmn

--- a/_posts/2021/2021-09-13-don-okuda-is-an-abboteer.md
+++ b/_posts/2021/2021-09-13-don-okuda-is-an-abboteer.md
@@ -2,18 +2,20 @@
 title: "Don Okuda is an Abboteer"
 description: "Actual Human Don Okuda joins A Serious Business, Inc."
 tags: [team, new-hire, abboteer]
-excerpt_image: https://user-images.githubusercontent.com/279389/133147424-0cfa12fd-12d3-4e71-9ab8-97e58a041901.jpg
+excerpt_image:
+    url: https://user-images.githubusercontent.com/279389/133147424-0cfa12fd-12d3-4e71-9ab8-97e58a041901.jpg
+    title: "Don made a clean escape so he could join us"
 author:
     avatar: https://avatars.githubusercontent.com/u/279389?s=400&u=74e6e598a2bf9d9889fbb771c542c508bf270e36
     name: pmn
 ---
 
-We’re excited to share that Don Okuda has joined us as a Founding Product Designer to help make Abbot even more enjoyable to use. 
+We’re excited to share that Don Okuda has joined us as a Founding Product Designer to help make Abbot even more enjoyable to use.
 
-![Don escaped so he could join us](https://user-images.githubusercontent.com/279389/133147424-0cfa12fd-12d3-4e71-9ab8-97e58a041901.jpg)
+![Don Okuda bundled inside a washing machine with clothes and just his head peeking out.](https://user-images.githubusercontent.com/279389/133147424-0cfa12fd-12d3-4e71-9ab8-97e58a041901.jpg "Don made a clean escape so he could join us")
 
-We all worked with Don at GitHub on GitHub Desktop and can’t wait to work with him more here. 
+We all worked with Don at GitHub on GitHub Desktop and can’t wait to work with him more here.
 
-When he’s not making great products, Don makes music and enjoys pineapple on his pizza. 
+When he’s not making great products, Don makes music and enjoys pineapple on his pizza.
 
 Don insists he’s an actual human, so please join us in welcoming him to A Serious Business!

--- a/_posts/2021/2021-11-03-how-cascadiajs-uses-abbot.md
+++ b/_posts/2021/2021-11-03-how-cascadiajs-uses-abbot.md
@@ -2,13 +2,17 @@
 title: "Updating the CascadiaJS live stream with Abbot"
 description: "CascadiaJS uses Abbot patterns to power its live feed. See how to use Patterns in this post"
 tags: [patterns,cascadiajs,abbot]
-excerpt_image: 
+excerpt_image:
+  url: https://user-images.githubusercontent.com/19977/140583949-f03ce751-5708-4eaa-a14a-fa2b03d43737.png
+  title: "Abbot can be used in flexible ways"
 author:
     avatar: https://avatars.githubusercontent.com/u/279389?s=400&u=74e6e598a2bf9d9889fbb771c542c508bf270e36&v=4
     name: pmn
 ---
 
-If you attended [CascadiaJS 2021](https://2021.cascadiajs.com/), you may have noticed live updates on the website that came from Cascadia's Discord server. 
+If you attended [CascadiaJS 2021](https://2021.cascadiajs.com/), you may have noticed live updates on the website that came from Cascadia's Discord server.
+
+![Cascadia's website live stream with Discord chat messages relayed to the right sidebar](https://user-images.githubusercontent.com/19977/140583949-f03ce751-5708-4eaa-a14a-fa2b03d43737.png "Abbot can be used in flexible ways")
 
 The CascadiaJS team did this using [Abbot](https://ab.bot/). They installed Abbot into their Discord server, and created a command called “channel-sync” that listens for messages in a room they’ve set up. Any time someone sends a message, Abbot takes that message and some metadata about who sent it and posts it to an external server in order to update the live feed. Brenden Niedermeyer is one of the organizers of CascadiaJS, and he blogged about building their live update system in [this post](https://brenden.codes/cascadiajs-building-live-experiences-with-web-components).
 

--- a/_posts/2021/2021-11-03-how-cascadiajs-uses-abbot.md
+++ b/_posts/2021/2021-11-03-how-cascadiajs-uses-abbot.md
@@ -5,6 +5,7 @@ tags: [patterns,cascadiajs,abbot]
 excerpt_image:
   url: https://user-images.githubusercontent.com/19977/140583949-f03ce751-5708-4eaa-a14a-fa2b03d43737.png
   title: "Abbot can be used in flexible ways"
+  alt: Cascadia's website live stream with Discord chat messages relayed to the right sidebar
 author:
     avatar: https://avatars.githubusercontent.com/u/279389?s=400&u=74e6e598a2bf9d9889fbb771c542c508bf270e36&v=4
     name: pmn

--- a/_posts/2021/2021-11-03-introducing-patterns.md
+++ b/_posts/2021/2021-11-03-introducing-patterns.md
@@ -5,6 +5,7 @@ tags: [patterns,abbot]
 excerpt_image:
     url: https://user-images.githubusercontent.com/19977/139963499-5f0db4c3-a72e-4bad-8419-d1ac247c676c.jpeg
     title: Puzzle image dedicated to the public domain by the author.
+    alt: Puzzle with last piece fitting in
 author:
     avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
     name: haacked
@@ -14,7 +15,7 @@ Until recently, to call an Abbot skill, you issued a command that specified the 
 
 Since every skill has a unique name, this approach is easy to reason about. It's always clear which skill will respond to a given command. However, there are cases where it would be nice for Abbot to not be restricted to direct commands. For example, you may want alternative ways of calling a skill that feel more natural in the situation. Or you may want Abbot to act more proactively to content in messages such as when someone mentions a tracking number.
 
-![Puzzle with last piece fitting in - Image dedicated to the public domain](https://user-images.githubusercontent.com/19977/139963499-5f0db4c3-a72e-4bad-8419-d1ac247c676c.jpeg "Puzzle image dedicated to the public domain by the author.")
+![Puzzle with last piece fitting in](https://user-images.githubusercontent.com/19977/139963499-5f0db4c3-a72e-4bad-8419-d1ac247c676c.jpeg "Puzzle image dedicated to the public domain by the author.")
 
 Well now such skills are possible with the new Abbot feature, Patterns! Patterns allow you to configure listeners in Abbot that pay attention to specific words and phrases. When a pattern matches, the associated skill is called. Patterns can match the beginning or end of a message, or even use a regular expression to match a message.
 

--- a/_posts/2021/2021-11-03-introducing-patterns.md
+++ b/_posts/2021/2021-11-03-introducing-patterns.md
@@ -2,7 +2,9 @@
 title: "Introducing Patterns"
 description: "Patterns give Abbot the ability to respond to any message, not just commands."
 tags: [patterns,abbot]
-excerpt_image: https://user-images.githubusercontent.com/19977/139963499-5f0db4c3-a72e-4bad-8419-d1ac247c676c.jpeg
+excerpt_image:
+    url: https://user-images.githubusercontent.com/19977/139963499-5f0db4c3-a72e-4bad-8419-d1ac247c676c.jpeg
+    title: Puzzle image dedicated to the public domain by the author.
 author:
     avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
     name: haacked


### PR DESCRIPTION
For our blog, we tend to have a primary image for the post. Usually after the first paragraph of the post. When we add such an image, we should always add both `alt` text and `title` text.

For example:

`![Alt text describes content of image for vision impared](https://url-to-image "Title text provides a caption to the image")`

Note that we have some JavaScript that renders the title of the image below the image below the image like so:

![Screen Shot 2021-11-05 at 3 11 38 PM](https://user-images.githubusercontent.com/19977/140584230-99e8b190-ec24-47a2-8a1a-036091e1d977.png)

This is a great opportunity to add some funny commentary or extra context to the image. For images that we did not create, we should use the title to provide attribution for the image.

However, we also use the `excerpt_image` front matter to display the image on the home page. Prior to the recent changes I made to https://github.com/aseriousbiz/blog-theme, we didn't have a way to add a title attribute to the home page. Now we do. We should also add the `alt` text to the front-matter for the `excerpt_image`.