### PR TITLE
Remove extraneous whitespace at the end of posts

### DIFF
--- a/_posts/2021/2021-07-01-graphs-in-chat.markdown
+++ b/_posts/2021/2021-07-01-graphs-in-chat.markdown
@@ -102,5 +102,3 @@ Run `@abbot help grafana` for general help with the skill, or `@abbot grafana he
 You can find the source for this skill on our [skills repository](https://github.com/aseriousbiz/abbot-skills/blob/main/skills/grafana.cs). If you have any issues or improvement suggestions, go ahead and open an issue or send us a pull request in that repository.
 
 Happy graphing!
-
-.

--- a/_posts/2021/2021-07-15-tools-for-inside-the-workshop.md
+++ b/_posts/2021/2021-07-15-tools-for-inside-the-workshop.md
@@ -65,6 +65,3 @@ bot.reply("Your string is {} characters long ({} words)".format(chars, words))
 ```
 
 [^2]: [read-eval-print-loop](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)
-
-
-

--- a/_posts/2021/2021-11-03-how-cascadiajs-uses-abbot.md
+++ b/_posts/2021/2021-11-03-how-cascadiajs-uses-abbot.md
@@ -56,7 +56,3 @@ Once this is enabled, jump into any chat room that has Abbot in it, and try aski
 The pattern above registered a listener (which we call a Pattern) and attached it to the `website-checker` skill you created. You can see all the patterns that Abbot is configured to use by visiting [https://ab.bot/skills/patterns/all](https://ab.bot/skills/patterns/all). Now any time someone asks if a website is down in a room with Abbot, it will do all the work of checking.
 
 Patterns can contain any kind of regular expression. [You can read more about them here]({% post_url 2021/2021-11-03-introducing-patterns %}).
-
-
-
-&nbsp; 


### PR DESCRIPTION
This whitespace was added to add some spacing between the end of the post and the text about suggesting an edit. This is now fixed using CSS as deity intended.